### PR TITLE
Do not include _force in JSON body of the request

### DIFF
--- a/constructor_io/constructor_io.py
+++ b/constructor_io/constructor_io.py
@@ -59,7 +59,10 @@ class ConstructorIO(object):
             return resp.json()
 
     def extract_params_from_kwargs(self, params, **kwargs):
-        params.update({k: v for k, v in kwargs.items()})
+        # The '_force' kwarg just indicates that `force` should be added
+        # to the query string, but it shouldn't be in the JSON body of the
+        # request
+        params.update({k: v for k, v in kwargs.items() if k != '_force'})
 
     def add(self, item_name, autocomplete_section, **kwargs):
         if not self._api_token:
@@ -121,7 +124,7 @@ class ConstructorIO(object):
                           "Batch method!")
         kwargs["_force"] = 1
         return self.add_batch(items, autocomplete_section, **kwargs)
-        
+
     def remove(self, item_name, autocomplete_section):
         params = {"item_name": item_name,
                   "autocomplete_section": autocomplete_section}


### PR DESCRIPTION
tldr; keeping the _force param in the JSON body of the request causes the back-end to reject the request because it doesn't recognize it. the `_force` kwarg [seems to be](https://github.com/Constructor-io/constructorio-python/blob/master/constructor_io/constructor_io.py#L103) just an indication that `force` should be added to the query string
See discussion in engineroom for context (~11am PST on Jan. 12th)