### PR TITLE
Bump requests version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,18 @@
-__pycache__
-*.pyc
-MANIFEST
-dist
-.idea/
+ # Byte-compiled / optimized / DLL files
+ __pycache__/
+ *.py[cod]
+ *$py.class
+ 
+ # IDE
+ .idea/
+ 
+ # Distribution / packaging
+ dist
+ MANIFEST
+ 
+ # Unit test / coverage reports
+ .cache
+ 
+ # Environments
+ venv/
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+mock==3.0.5
+pytest==3.3.1
+requests-mock==1.7.0

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,3 +1,1 @@
--r requirements.txt
-
 wsgiref==0.1.2

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,1 +1,3 @@
+-r requirements.txt
+
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ contextlib2==0.4.0
 funcsigs==0.4
 mock==1.3.0
 pbr==1.8.0
-requests==2.7.0
+requests==2.23.0
 six==1.10.0
 vcrpy==1.11.1
 wrapt==1.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
+attrs==19.1.0
 argparse==1.2.1
 contextlib2==0.4.0
-funcsigs==0.4
-mock==1.3.0
 pbr==1.8.0
 requests==2.23.0
 six==1.10.0
 vcrpy==1.11.1
 wrapt==1.10.5
-pytest==3.3.1
-requests-mock==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 from setuptools import setup
-from pip._internal.req import parse_requirements
+from pkg_resources import parse_requirements
 
 VERSION = "0.0.11"
 
-requirements_py3 = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
-requirements_py2 = [str(r.req) for r in parse_requirements('requirements-py2.txt', session=False)]
-install_requires = [
-    '%s; python_version>="3"' % req for req in requirements_py3
-] + [
-    '%s; python_version<"3"' % req for req in requirements_py2
+with open('requirements.txt', 'r') as f:
+    requirements = list(map(str, parse_requirements(f)))
+
+with open('requirements-py2.txt', 'r') as f:
+    extra_py2_requirements = list(map(str, parse_requirements(f)))
+
+install_requires = requirements + [
+    '%s; python_version<"3"' % req for req in extra_py2_requirements
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 from setuptools import setup
+from pip._internal.req import parse_requirements
 
 VERSION = "0.0.11"
+
+requirements_py3 = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
+requirements_py2 = [str(r.req) for r in parse_requirements('requirements-py2.txt', session=False)]
+install_requires = [
+    '%s; python_version>="3"' % req for req in requirements_py3
+] + [
+    '%s; python_version<"3"' % req for req in requirements_py2
+]
 
 setup(
     name="constructor-io",
@@ -12,10 +21,7 @@ setup(
     author="Constructor.io",
     author_email="info@constructor.io",
     url="https://www.constructor.io",
-    install_requires=[
-        "requests==2.7.0",
-        "vcrpy==1.11.1",
-    ],
+    install_requires=install_requires,
     packages=["constructor_io"],
     classifiers=[
         "Topic :: Internet",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-from pkg_resources import parse_requirements
 
 VERSION = "0.0.11"
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,6 @@ from pkg_resources import parse_requirements
 
 VERSION = "0.0.11"
 
-with open('requirements.txt', 'r') as f:
-    requirements = list(map(str, parse_requirements(f)))
-
-with open('requirements-py2.txt', 'r') as f:
-    extra_py2_requirements = list(map(str, parse_requirements(f)))
-
-install_requires = requirements + [
-    '%s; python_version<"3"' % req for req in extra_py2_requirements
-]
 
 setup(
     name="constructor-io",
@@ -23,7 +14,9 @@ setup(
     author="Constructor.io",
     author_email="info@constructor.io",
     url="https://www.constructor.io",
-    install_requires=install_requires,
+    install_requires=[
+        'requests~=2.7'
+    ],
     packages=["constructor_io"],
     classifiers=[
         "Topic :: Internet",


### PR DESCRIPTION
An updated version of https://github.com/Constructor-io/constructorio-python/pull/13

**Changes**
- require requests==2.23.0
- separate dev-requirements.txt
- proper `install_requires` in setup.py: account all requirements for different python versions

**Motivation**
In DP we either getting 
```
ERROR: constructor-io 0.0.10 has requirement requests==2.7.0, but you'll have requests 2.23.0 which is incompatible
```
or 
```
ERROR: spacy 2.0.18 has requirement requests<3.0.0,>=2.13.0, but you'll have requests 2.7.0 which is incompatible.
ERROR: geoip2 3.0.0 has requirement requests>=2.22.0, but you'll have requests 2.7.0 which is incompatible.
```