### PR TITLE
Update constructor_io.py

### DIFF
--- a/constructor_io/__init__.py
+++ b/constructor_io/__init__.py
@@ -1,3 +1,3 @@
 from .constructor_io import *  # noqa
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 VERSION = tuple(map(int, __version__.split('.')))

--- a/constructor_io/constructor_io.py
+++ b/constructor_io/constructor_io.py
@@ -57,7 +57,7 @@ class ConstructorIO(object):
         """
         if sort:
             params = sorted(params.items(), key=lambda val: val[0])
-        return urlencode(params)
+        return urlencode(params, doseq=True)
 
     def _make_url(self, endpoint, params=None):
         if not params:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 
 setup(

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -22,9 +22,8 @@ class TestConstructorIO(TestCase):
         constructor = ConstructorIO(api_token="boinka",
                                     key="doinka")
         serialized_params = constructor._serialize_params(
-            {'foo': [1, 2], 'bar': {'baz': ['a', 'b']}}, sort=True)
-        assert serialized_params == "bar=%7B%27baz%27%3A+%5B%27a%27%2C+" \
-                                    "%27b%27%5D%7D&foo=%5B1%2C+2%5D"
+            {'foo': [1, 2], 'bar': ['a', 'b']}, sort=True)
+        assert serialized_params == 'bar=a&bar=b&foo=1&foo=2'
 
     def test_key_argument(self):
         # Usual:


### PR DESCRIPTION
Constructor.io API has parameters of type list and they must be encoded as `&param=value1&param=value2`. 