### PR TITLE
[CSL-2015] Update CRABS request tests to point to new index

### DIFF
--- a/tests/modules/test_autocomplete.py
+++ b/tests/modules/test_autocomplete.py
@@ -11,7 +11,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 VALID_CLIENT_ID = '2b23dd74-5672-4379-878c-9182938d2710'
 VALID_SESSION_ID = 2
 VALID_OPTIONS = { 'api_key': TEST_API_KEY }
@@ -274,7 +274,7 @@ def test_with_invalid_api_key():
 
     with raises(
             HttpException,
-            match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.' # pylint: disable=line-too-long
+            match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.' # pylint: disable=line-too-long
     ):
         autocomplete = ConstructorIO({
             **VALID_OPTIONS,

--- a/tests/modules/test_browse.py
+++ b/tests/modules/test_browse.py
@@ -171,7 +171,8 @@ def test_get_browse_results_with_valid_filter_name_filter_value_and_fmt_options(
     assert isinstance(response.get('request'), dict)
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
-    assert response.get('request').get('fmt_options') == fmt_options
+    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
+    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
 
 
 def test_get_browse_results_with_valid_filter_name_filter_value_and_sort_by():
@@ -880,7 +881,8 @@ def test_get_browse_results_for_item_ids_with_valid_item_ids_and_fmt_options():
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
     assert isinstance(response.get('response').get('results'), list)
-    assert response.get('request').get('fmt_options') == fmt_options
+    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
+    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
 
 
 def test_get_browse_results_for_item_ids_with_valid_item_ids_and_sort_by():

--- a/tests/modules/test_browse.py
+++ b/tests/modules/test_browse.py
@@ -11,7 +11,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 VALID_CLIENT_ID = '2b23dd74-5672-4379-878c-9182938d2710'
 VALID_SESSION_ID = 2
@@ -480,7 +480,7 @@ def test_get_browse_results_with_invalid_api_key():
 
     with raises(
             HttpException,
-            match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.'  # pylint: disable=line-too-long
+            match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.'  # pylint: disable=line-too-long
     ):
         browse = ConstructorIO({
             **VALID_OPTIONS,
@@ -624,7 +624,7 @@ def test_get_browse_groups_with_invalid_fmt_options():
 def test_get_browse_groups_with_invalid_api_key():
     '''Should return a response with invalid api_key'''
 
-    with raises(HttpException, match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.'): # pylint: disable=line-too-long
+    with raises(HttpException, match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.'): # pylint: disable=line-too-long
         browse = ConstructorIO({'api_key': 'fyzs7tfF8L161VoAXQ8u'}).browse
         browse.get_browse_groups()
 
@@ -734,7 +734,7 @@ def test_get_browse_facets_with_invalid_fmt_options():
 def test_get_browse_facets_with_invalid_api_key():
     '''Should return a response with invalid api_key'''
 
-    with raises(HttpException, match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.'): # pylint: disable=line-too-long
+    with raises(HttpException, match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.'): # pylint: disable=line-too-long
         browse = ConstructorIO({'api_key': 'fyzs7tfF8L161VoAXQ8u'}).browse
         browse.get_browse_facets()
 
@@ -1168,7 +1168,7 @@ def test_get_browse_results_for_item_ids_with_invalid_api_key():
 
     with raises(
             HttpException,
-            match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.'  # pylint: disable=line-too-long
+            match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.'  # pylint: disable=line-too-long
     ):
         browse = ConstructorIO({
             **VALID_OPTIONS,
@@ -1278,6 +1278,6 @@ def test_get_browse_facet_options_with_invalid_fmt_options():
 def test_get_browse_facet_options_with_invalid_api_key():
     '''Should return a response with invalid api_key'''
 
-    with raises(HttpException, match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.'): # pylint: disable=line-too-long
+    with raises(HttpException, match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.'): # pylint: disable=line-too-long
         browse = ConstructorIO({'api_key': 'fyzs7tfF8L161VoAXQ8u'}).browse
         browse.get_browse_facet_options(FACET_NAME)

--- a/tests/modules/test_browse.py
+++ b/tests/modules/test_browse.py
@@ -171,8 +171,7 @@ def test_get_browse_results_with_valid_filter_name_filter_value_and_fmt_options(
     assert isinstance(response.get('request'), dict)
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
-    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
-    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
+    assert response.get('request').get('fmt_options') == fmt_options
 
 
 def test_get_browse_results_with_valid_filter_name_filter_value_and_sort_by():
@@ -395,7 +394,7 @@ def test_get_browse_results_with_no_filter_value():
 def test_get_browse_results_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page: value is not a valid integer'):
+    with raises(HttpException, match=r'page must be an integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -407,7 +406,7 @@ def test_get_browse_results_with_invalid_page():
 def test_get_browse_results_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
+    with raises(HttpException, match=r'num_results_per_page must be an integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -431,7 +430,7 @@ def test_get_browse_results_with_invalid_filters():
 def test_get_browse_results_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by: str type expected'):
+    with raises(HttpException, match=r'sort_by must be a string'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -443,7 +442,7 @@ def test_get_browse_results_with_invalid_sort_by():
 def test_get_browse_results_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
+    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -705,7 +704,7 @@ def test_get_browse_facets_with_section():
 def test_get_browse_facets_with_invalid_page():
     '''Should return a response with invalid page'''
 
-    with raises(HttpException, match=r'page: value is not a valid integer'):
+    with raises(HttpException, match=r'page must be an integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_facets(
             { 'page': 'abc'},
@@ -715,7 +714,7 @@ def test_get_browse_facets_with_invalid_page():
 def test_get_browse_facets_with_invalid_results_per_page():
     '''Should return a response with invalid results_per_page'''
 
-    with raises(HttpException, match=r'results_per_page: value is not a valid integer'):
+    with raises(HttpException, match=r'results_per_page must be an integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_facets(
             { 'results_per_page': 'abc'},
@@ -881,8 +880,7 @@ def test_get_browse_results_for_item_ids_with_valid_item_ids_and_fmt_options():
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
     assert isinstance(response.get('response').get('results'), list)
-    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
-    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
+    assert response.get('request').get('fmt_options') == fmt_options
 
 
 def test_get_browse_results_for_item_ids_with_valid_item_ids_and_sort_by():
@@ -1091,7 +1089,7 @@ def test_get_browse_results_for_item_ids_with_invalid_item_ids():
 def test_get_browse_results_for_item_ids_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page: value is not a valid integer'):
+    with raises(HttpException, match=r'page must be an integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1102,7 +1100,7 @@ def test_get_browse_results_for_item_ids_with_invalid_page():
 def test_get_browse_results_for_item_ids_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
+    with raises(HttpException, match=r'num_results_per_page must be an integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1124,7 +1122,7 @@ def test_get_browse_results_for_item_ids_with_invalid_filters():
 def test_get_browse_results_for_item_ids_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by: str type expected'):
+    with raises(HttpException, match=r'sort_by must be a string'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1135,7 +1133,7 @@ def test_get_browse_results_for_item_ids_with_invalid_sort_by():
 def test_get_browse_results_for_item_ids_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
+    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,

--- a/tests/modules/test_browse.py
+++ b/tests/modules/test_browse.py
@@ -171,7 +171,8 @@ def test_get_browse_results_with_valid_filter_name_filter_value_and_fmt_options(
     assert isinstance(response.get('request'), dict)
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
-    assert response.get('request').get('fmt_options') == fmt_options
+    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
+    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
 
 
 def test_get_browse_results_with_valid_filter_name_filter_value_and_sort_by():
@@ -394,7 +395,7 @@ def test_get_browse_results_with_no_filter_value():
 def test_get_browse_results_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page must be an integer'):
+    with raises(HttpException, match=r'page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -406,7 +407,7 @@ def test_get_browse_results_with_invalid_page():
 def test_get_browse_results_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page must be an integer'):
+    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -430,7 +431,7 @@ def test_get_browse_results_with_invalid_filters():
 def test_get_browse_results_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by must be a string'):
+    with raises(HttpException, match=r'sort_by: str type expected'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -442,7 +443,7 @@ def test_get_browse_results_with_invalid_sort_by():
 def test_get_browse_results_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
+    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -704,7 +705,7 @@ def test_get_browse_facets_with_section():
 def test_get_browse_facets_with_invalid_page():
     '''Should return a response with invalid page'''
 
-    with raises(HttpException, match=r'page must be an integer'):
+    with raises(HttpException, match=r'page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_facets(
             { 'page': 'abc'},
@@ -714,7 +715,7 @@ def test_get_browse_facets_with_invalid_page():
 def test_get_browse_facets_with_invalid_results_per_page():
     '''Should return a response with invalid results_per_page'''
 
-    with raises(HttpException, match=r'results_per_page must be an integer'):
+    with raises(HttpException, match=r'results_per_page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_facets(
             { 'results_per_page': 'abc'},
@@ -880,7 +881,8 @@ def test_get_browse_results_for_item_ids_with_valid_item_ids_and_fmt_options():
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
     assert isinstance(response.get('response').get('results'), list)
-    assert response.get('request').get('fmt_options') == fmt_options
+    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
+    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
 
 
 def test_get_browse_results_for_item_ids_with_valid_item_ids_and_sort_by():
@@ -1089,7 +1091,7 @@ def test_get_browse_results_for_item_ids_with_invalid_item_ids():
 def test_get_browse_results_for_item_ids_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page must be an integer'):
+    with raises(HttpException, match=r'page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1100,7 +1102,7 @@ def test_get_browse_results_for_item_ids_with_invalid_page():
 def test_get_browse_results_for_item_ids_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page must be an integer'):
+    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1122,7 +1124,7 @@ def test_get_browse_results_for_item_ids_with_invalid_filters():
 def test_get_browse_results_for_item_ids_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by must be a string'):
+    with raises(HttpException, match=r'sort_by: str type expected'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1133,7 +1135,7 @@ def test_get_browse_results_for_item_ids_with_invalid_sort_by():
 def test_get_browse_results_for_item_ids_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
+    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,

--- a/tests/modules/test_catalog_csv.py
+++ b/tests/modules/test_catalog_csv.py
@@ -11,7 +11,7 @@ from pytest import raises
 from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import HttpException
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_CATALOG_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN }
 SECTION = 'Products'

--- a/tests/modules/test_catalog_items.py
+++ b/tests/modules/test_catalog_items.py
@@ -10,7 +10,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import HttpException
 from tests.helpers.utils import create_mock_item, create_mock_variation
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_CATALOG_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN }
 SECTION = 'Products'

--- a/tests/modules/test_catalog_items.py
+++ b/tests/modules/test_catalog_items.py
@@ -70,7 +70,7 @@ def test_with_create_or_replace_items_no_items():
 
     with raises(
         HttpException,
-        match=r'items must be a list'
+        match=r'items: none is not an allowed value'
     ):
         catalog.create_or_replace_items({})
 
@@ -134,7 +134,7 @@ def test_with_update_items_no_items():
 
     with raises(
         HttpException,
-        match=r'items must be a list'
+            match=r'items: none is not an allowed value'
     ):
         catalog.update_items({})
 

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -8,7 +8,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 QUIZ_ID = 'test-quiz'
 VALID_QUIZ_ANS = [[1], [1, 2], ['seen']]

--- a/tests/modules/test_recommendations.py
+++ b/tests/modules/test_recommendations.py
@@ -11,7 +11,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 VALID_CLIENT_ID = '2b23dd74-5672-4379-878c-9182938d2710'
 VALID_SESSION_ID = 2
 VALID_OPTIONS = { 'api_key': TEST_API_KEY }
@@ -320,7 +320,7 @@ def test_with_invalid_api_key():
 
     with raises(
             HttpException,
-            match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.' # pylint: disable=line-too-long
+            match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.' # pylint: disable=line-too-long
     ):
         recommendations = ConstructorIO({
             **VALID_OPTIONS,

--- a/tests/modules/test_search.py
+++ b/tests/modules/test_search.py
@@ -132,7 +132,8 @@ def test_with_valid_query_and_fmt_options():
     assert isinstance(response.get('request'), dict)
     assert isinstance(response.get('response'), dict)
     assert isinstance(response.get('result_id'), str)
-    assert response.get('request').get('fmt_options') == fmt_options
+    assert response.get('request').get('fmt_options').get('groups_max_depth') == 2
+    assert response.get('request').get('fmt_options').get('groups_start') == 'current'
 
 def test_with_valid_query_and_sort_by():
     '''Should return a response with a valid query, section, and sort_by'''
@@ -328,14 +329,14 @@ def test_with_no_query():
 def test_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page must be an integer'):
+    with raises(HttpException, match=r'page: value is not a valid integer'):
         search = ConstructorIO(VALID_OPTIONS).search
         search.get_search_results(QUERY, { 'section': SECTION, 'page': 'abc' })
 
 def test_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page must be an integer'):
+    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
         search = ConstructorIO(VALID_OPTIONS).search
         search.get_search_results(QUERY, { 'section': SECTION, 'results_per_page': 'abc' })
 
@@ -349,14 +350,14 @@ def test_with_invalid_filters():
 def test_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by must be a string'):
+    with raises(HttpException, match=r'sort_by: str type expected'):
         search = ConstructorIO(VALID_OPTIONS).search
         search.get_search_results(QUERY, { 'section': SECTION, 'sort_by': ['foo', 'bar'] })
 
 def test_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
+    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
         search = ConstructorIO(VALID_OPTIONS).search
         search.get_search_results(QUERY, { 'section': SECTION, 'sort_order': 123 })
 

--- a/tests/modules/test_search.py
+++ b/tests/modules/test_search.py
@@ -357,7 +357,7 @@ def test_with_invalid_sort_by():
 def test_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
+    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"): # pylint: disable=line-too-long
         search = ConstructorIO(VALID_OPTIONS).search
         search.get_search_results(QUERY, { 'section': SECTION, 'sort_order': 123 })
 

--- a/tests/modules/test_search.py
+++ b/tests/modules/test_search.py
@@ -11,7 +11,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 VALID_CLIENT_ID = '2b23dd74-5672-4379-878c-9182938d2710'
 VALID_SESSION_ID = 2
 VALID_OPTIONS = { 'api_key': TEST_API_KEY }
@@ -372,7 +372,7 @@ def test_with_invalid_api_key():
 
     with raises(
             HttpException,
-            match=r'We have no record of this key. You can find your key at app.constructor.io/dashboard.' # pylint: disable=line-too-long
+            match=r'You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.' # pylint: disable=line-too-long
     ):
         search = ConstructorIO({
             **VALID_OPTIONS,

--- a/tests/modules/test_tasks.py
+++ b/tests/modules/test_tasks.py
@@ -10,7 +10,7 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_CATALOG_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN}
 CATALOG_EXAMPLES_BASE_URL = 'https://raw.githubusercontent.com/Constructor-io/integration-examples/main/catalog/' #pylint: disable=line-too-long

--- a/tests/test_constructorio.py
+++ b/tests/test_constructorio.py
@@ -7,7 +7,7 @@ import pytest
 from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import ConstructorException
 
-TEST_API_KEY = environ['TEST_API_KEY']
+TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 VALID_OPTIONS = { 'api_key': TEST_API_KEY }
 
 def test_with_valid_api_key():


### PR DESCRIPTION
There are 9 failing requests due to `section` parameter. Those should be resolved when backend releases the change next week