### PR TITLE
[CSL-2233/CSL-2210] Updates to Support Quizzes API

### DIFF
--- a/constructor_io/modules/quizzes.py
+++ b/constructor_io/modules/quizzes.py
@@ -22,7 +22,7 @@ def _create_quizzes_url(quiz_id, parameters, user_parameters, options, path):
     if not quiz_id or not isinstance(quiz_id, str):
         raise ConstructorException('quiz_id is a required parameter of type str')
 
-    if path == 'finalize' and (not isinstance(parameters.get('answers'), list) or len(parameters.get('answers')) == 0): # pylint: disable=line-too-long
+    if path == 'results' and (not isinstance(parameters.get('answers'), list) or len(parameters.get('answers')) == 0): # pylint: disable=line-too-long
         raise ConstructorException('answers is a required parameter of type list')
 
     if parameters:
@@ -123,7 +123,7 @@ class Quizzes:
         if not user_parameters:
             user_parameters = {}
 
-        request_url = _create_quizzes_url(quiz_id, parameters, user_parameters, self.__options, 'finalize') #pylint: disable=line-too-long
+        request_url = _create_quizzes_url(quiz_id, parameters, user_parameters, self.__options, 'results') #pylint: disable=line-too-long
         requests = self.__options.get('requests') or r
 
         response = requests.get(

--- a/constructor_io/modules/quizzes.py
+++ b/constructor_io/modules/quizzes.py
@@ -29,8 +29,11 @@ def _create_quizzes_url(quiz_id, parameters, user_parameters, options, path):
         if parameters.get('section'):
             query_params['section'] = parameters.get('section')
 
-        if parameters.get('version_id'):
-            query_params['version_id'] = parameters.get('version_id')
+        if parameters.get('quiz_version_id'):
+            query_params['quiz_version_id'] = parameters.get('quiz_version_id')
+
+        if parameters.get('quiz_session_id'):
+            query_params['quiz_session_id'] = parameters.get('quiz_session_id')
 
         if parameters.get('answers'):
             answers_param = []
@@ -62,7 +65,8 @@ class Quizzes:
         :param dict parameters: Additional parameters to determine next quiz
         :param list parameters.answers: 2d Array of quiz answers in the format [[1],[1,2]]
         :param str parameters.section: Section for customer's product catalog
-        :param str parameters.version_id: Specific version_id for the quiz
+        :param str parameters.quiz_version_id: Specific quiz_version_id for the quiz. Version ID will be returned with the first request and it should be passed with subsequent requests. More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
+        :param str parameters.quiz_session_id: Specific quiz_session_id for the quiz. Session ID will be returned with the first request and it should be passed with subsequent requests. More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-sessions
         :param dict user_parameters: Parameters relevant to the user request
         :param int user_parameters.session_id: Session ID, utilized to personalize results
         :param str user_parameters.client_id: Client ID, utilized to personalize results
@@ -91,7 +95,7 @@ class Quizzes:
         json = response.json()
 
         if json:
-            if json.get('version_id'):
+            if json.get('quiz_version_id'):
                 return json
 
         raise ConstructorException('get_quiz_next_question response data is malformed')
@@ -104,7 +108,8 @@ class Quizzes:
         :param dict parameters: Additional parameters to determine next quiz
         :param list parameters.answers: 2d Array of quiz answers in the format [[1],[1,2]]
         :param str parameters.section: Section for customer's product catalog
-        :param str parameters.version_id: Specific version_id for the quiz
+        :param str parameters.quiz_version_id: Specific quiz_version_id for the quiz. Version ID will be returned with the first request and it should be passed with subsequent requests. More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
+        :param str parameters.quiz_session_id: Specific quiz_session_id for the quiz. Session ID will be returned with the first request and it should be passed with subsequent requests. More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-sessions
         :param dict user_parameters: Parameters relevant to the user request
         :param int user_parameters.session_id: Session ID, utilized to personalize results
         :param str user_parameters.client_id: Client ID, utilized to personalize results
@@ -133,7 +138,7 @@ class Quizzes:
         json = response.json()
 
         if json:
-            if json.get('version_id'):
+            if json.get('quiz_version_id'):
                 return json
 
         raise ConstructorException('get_quiz_results response data is malformed')

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -71,13 +71,24 @@ def test_get_quiz_results_with_valid_parameters():
     '''Should return a response with a valid quiz_id, a(answers)'''
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
-    response = quizzes.get_quiz_results(QUIZ_ID, {'answers': VALID_QUIZ_ANS})
+    res = quizzes.get_quiz_results(QUIZ_ID, {'answers': VALID_QUIZ_ANS})
+    request = res.get('request')
+    response = res.get('response')
 
-    assert isinstance(response.get('quiz_id'), str)
-    assert isinstance(response.get('quiz_version_id'), str)
-    assert isinstance(response.get('quiz_session_id'), str)
-    assert isinstance(response.get('result'), dict)
-    assert isinstance(response.get('result').get('results_url'), str)
+    assert isinstance(res.get('quiz_id'), str)
+    assert isinstance(res.get('quiz_version_id'), str)
+    assert isinstance(res.get('quiz_session_id'), str)
+    assert isinstance(res.get('result_id'), str)
+    assert isinstance(request, dict)
+    assert isinstance(response, dict)
+    assert isinstance(response.get('total_num_results'), int)
+    assert isinstance(response.get('result_sources'), dict)
+    assert isinstance(response.get('results'), list)
+    assert isinstance(response.get('sort_options'), list)
+    assert isinstance(response.get('facets'), list)
+    assert isinstance(response.get('groups'), list)
+    assert isinstance(response.get('refined_content'), list)
+    assert isinstance(response.get('total_num_results'), int)
 
 def test_get_quiz_results_with_no_quiz_id():
     '''Should raise an exception with no quiz_id'''

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -27,7 +27,7 @@ def test_get_quiz_next_question_with_valid_parameters():
     assert isinstance(response.get('quiz_session_id'), str)
     assert isinstance(response.get('next_question'), dict)
 
-def test_get_quiz_next_question_should_repond_with_matching_parameters():
+def test_get_quiz_next_question_should_respond_with_matching_parameters():
     '''Should return a response with a matching quiz_id, quiz_version_id, quiz_session_id'''
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
@@ -105,7 +105,7 @@ def test_get_quiz_results_with_valid_parameters():
     assert isinstance(response.get('refined_content'), list)
     assert isinstance(response.get('total_num_results'), int)
 
-def test_get_quiz_results_should_repond_with_matching_parameters():
+def test_get_quiz_results_should_respond_with_matching_parameters():
     '''Should return a response with a matching quiz_id, quiz_version_id, quiz_session_id'''
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -32,7 +32,7 @@ def test_get_quiz_next_question_should_repond_with_matching_parameters():
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
     response = quizzes.get_quiz_next_question(QUIZ_ID, {
-        'quiz_version_id': QUIZ_VERSION_ID, 
+        'quiz_version_id': QUIZ_VERSION_ID,
         'quiz_session_id': QUIZ_SESSION_ID
         })
 
@@ -110,8 +110,8 @@ def test_get_quiz_results_should_repond_with_matching_parameters():
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
     res = quizzes.get_quiz_results(QUIZ_ID, {
-        'answers': VALID_QUIZ_ANS, 
-        'quiz_version_id': QUIZ_VERSION_ID, 
+        'answers': VALID_QUIZ_ANS,
+        'quiz_version_id': QUIZ_VERSION_ID,
         'quiz_session_id': QUIZ_SESSION_ID})
 
     assert res.get('quiz_id') == QUIZ_ID

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -31,7 +31,10 @@ def test_get_quiz_next_question_should_repond_with_matching_parameters():
     '''Should return a response with a matching quiz_id, quiz_version_id, quiz_session_id'''
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
-    response = quizzes.get_quiz_next_question(QUIZ_ID, {'quiz_version_id': QUIZ_VERSION_ID, "quiz_session_id": QUIZ_SESSION_ID})
+    response = quizzes.get_quiz_next_question(QUIZ_ID, {
+        'quiz_version_id': QUIZ_VERSION_ID, 
+        'quiz_session_id': QUIZ_SESSION_ID
+        })
 
     assert response.get('quiz_id') == QUIZ_ID
     assert response.get('quiz_version_id') == QUIZ_VERSION_ID
@@ -106,7 +109,10 @@ def test_get_quiz_results_should_repond_with_matching_parameters():
     '''Should return a response with a matching quiz_id, quiz_version_id, quiz_session_id'''
 
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
-    res = quizzes.get_quiz_results(QUIZ_ID, {'answers': VALID_QUIZ_ANS, 'quiz_version_id': QUIZ_VERSION_ID, "quiz_session_id": QUIZ_SESSION_ID})
+    res = quizzes.get_quiz_results(QUIZ_ID, {
+        'answers': VALID_QUIZ_ANS, 
+        'quiz_version_id': QUIZ_VERSION_ID, 
+        'quiz_session_id': QUIZ_SESSION_ID})
 
     assert res.get('quiz_id') == QUIZ_ID
     assert res.get('quiz_version_id') == QUIZ_VERSION_ID

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -20,7 +20,9 @@ def test_get_quiz_next_question_with_valid_parameters():
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
     response = quizzes.get_quiz_next_question('test-quiz')
 
-    assert isinstance(response.get('version_id'), str)
+    assert isinstance(response.get('quiz_id'), str)
+    assert isinstance(response.get('quiz_version_id'), str)
+    assert isinstance(response.get('quiz_session_id'), str)
     assert isinstance(response.get('next_question'), dict)
 
 def test_get_quiz_next_question_with_answer_parameter():
@@ -29,7 +31,9 @@ def test_get_quiz_next_question_with_answer_parameter():
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
     response = quizzes.get_quiz_next_question('test-quiz', { 'answers': VALID_QUIZ_ANS })
 
-    assert isinstance(response.get('version_id'), str)
+    assert isinstance(response.get('quiz_id'), str)
+    assert isinstance(response.get('quiz_version_id'), str)
+    assert isinstance(response.get('quiz_session_id'), str)
     assert isinstance(response.get('next_question'), dict)
     assert response.get('next_question').get('id') == 4
 
@@ -69,7 +73,9 @@ def test_get_quiz_results_with_valid_parameters():
     quizzes = ConstructorIO(VALID_OPTIONS).quizzes
     response = quizzes.get_quiz_results(QUIZ_ID, {'answers': VALID_QUIZ_ANS})
 
-    assert isinstance(response.get('version_id'), str)
+    assert isinstance(response.get('quiz_id'), str)
+    assert isinstance(response.get('quiz_version_id'), str)
+    assert isinstance(response.get('quiz_session_id'), str)
     assert isinstance(response.get('result'), dict)
     assert isinstance(response.get('result').get('results_url'), str)
 

--- a/tests/modules/test_quizzes.py
+++ b/tests/modules/test_quizzes.py
@@ -11,6 +11,8 @@ from constructor_io.helpers.exception import (ConstructorException,
 TEST_API_KEY = environ['TEST_REQUEST_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 QUIZ_ID = 'test-quiz'
+QUIZ_VERSION_ID = 'e03210db-0cc6-459c-8f17-bf014c4f554d'
+QUIZ_SESSION_ID = 'ca380401-3805-4ded-8f28-638e5a4baa92'
 VALID_QUIZ_ANS = [[1], [1, 2], ['seen']]
 VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN}
 
@@ -24,6 +26,16 @@ def test_get_quiz_next_question_with_valid_parameters():
     assert isinstance(response.get('quiz_version_id'), str)
     assert isinstance(response.get('quiz_session_id'), str)
     assert isinstance(response.get('next_question'), dict)
+
+def test_get_quiz_next_question_should_repond_with_matching_parameters():
+    '''Should return a response with a matching quiz_id, quiz_version_id, quiz_session_id'''
+
+    quizzes = ConstructorIO(VALID_OPTIONS).quizzes
+    response = quizzes.get_quiz_next_question(QUIZ_ID, {'quiz_version_id': QUIZ_VERSION_ID, "quiz_session_id": QUIZ_SESSION_ID})
+
+    assert response.get('quiz_id') == QUIZ_ID
+    assert response.get('quiz_version_id') == QUIZ_VERSION_ID
+    assert response.get('quiz_session_id') == QUIZ_SESSION_ID
 
 def test_get_quiz_next_question_with_answer_parameter():
     '''Should return a response with a valid quiz_id and answer parameter'''
@@ -89,6 +101,16 @@ def test_get_quiz_results_with_valid_parameters():
     assert isinstance(response.get('groups'), list)
     assert isinstance(response.get('refined_content'), list)
     assert isinstance(response.get('total_num_results'), int)
+
+def test_get_quiz_results_should_repond_with_matching_parameters():
+    '''Should return a response with a matching quiz_id, quiz_version_id, quiz_session_id'''
+
+    quizzes = ConstructorIO(VALID_OPTIONS).quizzes
+    res = quizzes.get_quiz_results(QUIZ_ID, {'answers': VALID_QUIZ_ANS, 'quiz_version_id': QUIZ_VERSION_ID, "quiz_session_id": QUIZ_SESSION_ID})
+
+    assert res.get('quiz_id') == QUIZ_ID
+    assert res.get('quiz_version_id') == QUIZ_VERSION_ID
+    assert res.get('quiz_session_id') == QUIZ_SESSION_ID
 
 def test_get_quiz_results_with_no_quiz_id():
     '''Should raise an exception with no quiz_id'''


### PR DESCRIPTION
- Refactored `version_id` to `quiz_version_id`
- Added support for `quiz_session_id`
- Updated tests to check for `quiz_version_id`, `quiz_session_id` and `quiz_id`
- Migrated from retrieving quizzes results from the /finalize endpoint to the /results endpoint