### PR TITLE
Bumps certifi from 2023.5.7 to 2023.7.22

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
-                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+                "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+                "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2023.5.7"
+            "index": "pypi",
+            "version": "==2023.7.22"
         },
         "charset-normalizer": {
             "hashes": [

--- a/tests/modules/test_browse.py
+++ b/tests/modules/test_browse.py
@@ -443,7 +443,10 @@ def test_get_browse_results_with_invalid_sort_by():
 def test_get_browse_results_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
+    with raises(
+        HttpException,
+        match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"
+        ):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -1135,7 +1138,10 @@ def test_get_browse_results_for_item_ids_with_invalid_sort_by():
 def test_get_browse_results_for_item_ids_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
+    with raises(
+        HttpException,
+        match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"
+        ):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,

--- a/tests/modules/test_browse.py
+++ b/tests/modules/test_browse.py
@@ -395,7 +395,7 @@ def test_get_browse_results_with_no_filter_value():
 def test_get_browse_results_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page must be an integer'):
+    with raises(HttpException, match=r'page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -407,7 +407,7 @@ def test_get_browse_results_with_invalid_page():
 def test_get_browse_results_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page must be an integer'):
+    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -431,7 +431,7 @@ def test_get_browse_results_with_invalid_filters():
 def test_get_browse_results_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by must be a string'):
+    with raises(HttpException, match=r'sort_by: str type expected'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -443,7 +443,7 @@ def test_get_browse_results_with_invalid_sort_by():
 def test_get_browse_results_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
+    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results(
             FILTER_NAME,
@@ -1091,7 +1091,7 @@ def test_get_browse_results_for_item_ids_with_invalid_item_ids():
 def test_get_browse_results_for_item_ids_with_invalid_page():
     '''Should raise exception when invalid page parameter is provided'''
 
-    with raises(HttpException, match=r'page must be an integer'):
+    with raises(HttpException, match=r'page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1102,7 +1102,7 @@ def test_get_browse_results_for_item_ids_with_invalid_page():
 def test_get_browse_results_for_item_ids_with_invalid_results_per_page():
     '''Should raise exception when invalid results_per_page parameter is provided'''
 
-    with raises(HttpException, match=r'num_results_per_page must be an integer'):
+    with raises(HttpException, match=r'num_results_per_page: value is not a valid integer'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1124,7 +1124,7 @@ def test_get_browse_results_for_item_ids_with_invalid_filters():
 def test_get_browse_results_for_item_ids_with_invalid_sort_by():
     '''Should raise exception when invalid sort_by parameter is provided'''
 
-    with raises(HttpException, match=r'sort_by must be a string'):
+    with raises(HttpException, match=r'sort_by: str type expected'):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,
@@ -1135,7 +1135,7 @@ def test_get_browse_results_for_item_ids_with_invalid_sort_by():
 def test_get_browse_results_for_item_ids_with_invalid_sort_order():
     '''Should raise exception when invalid sort_order parameter is provided'''
 
-    with raises(HttpException, match=r'Invalid value for parameter: "sort_order"'):
+    with raises(HttpException, match=r"sort_order: value is not a valid enumeration member; permitted: 'ascending', 'descending'"):
         browse = ConstructorIO(VALID_OPTIONS).browse
         browse.get_browse_results_for_item_ids(
             IDS,

--- a/tests/modules/test_catalog_csv.py
+++ b/tests/modules/test_catalog_csv.py
@@ -11,14 +11,15 @@ from pytest import raises
 from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import HttpException
 
+TIMEOUT = 60
 TEST_API_KEY = environ['TEST_CATALOG_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN }
 SECTION = 'Products'
 CATALOG_EXAMPLES_BASE_URL = 'https://raw.githubusercontent.com/Constructor-io/integration-examples/main/catalog/' #pylint: disable=line-too-long
-ITEMS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}items.csv').content
-VARIATIONS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}variations.csv').content
-ITEM_GROUPS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}item_groups.csv').content
+ITEMS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}items.csv', timeout=TIMEOUT).content
+VARIATIONS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}variations.csv', timeout=TIMEOUT).content
+ITEM_GROUPS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}item_groups.csv', timeout=TIMEOUT).content
 
 @pytest.fixture(autouse=True)
 def slow_down_tests():

--- a/tests/modules/test_tasks.py
+++ b/tests/modules/test_tasks.py
@@ -10,11 +10,12 @@ from constructor_io.constructor_io import ConstructorIO
 from constructor_io.helpers.exception import (ConstructorException,
                                               HttpException)
 
+TIMEOUT = 60
 TEST_API_KEY = environ['TEST_CATALOG_API_KEY']
 TEST_API_TOKEN = environ['TEST_API_TOKEN']
 VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN}
 CATALOG_EXAMPLES_BASE_URL = 'https://raw.githubusercontent.com/Constructor-io/integration-examples/main/catalog/' #pylint: disable=line-too-long
-ITEMS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}items.csv').content
+ITEMS = requests.get(f'{CATALOG_EXAMPLES_BASE_URL}items.csv', timeout=TIMEOUT).content
 
 #make a replace catalog request and get task_id to use in tests
 catalog = ConstructorIO(VALID_OPTIONS).catalog


### PR DESCRIPTION
See PR #59 by Dependabot.

Bumping certifi to 2023.7.22 resolves a high severity vulnerability as seen in this [Dependabot Alert](https://github.com/Constructor-io/constructorio-python/security/dependabot/5).

Tests are passing ✨

### Also in this PR
- Fix failing browse tests because backend changed their error messaging
- Fix some linting issues with our tests