### PR TITLE
[NO-CSL] Fix Autocomplete Tests due to a schema change

### DIFF
--- a/tests/modules/test_autocomplete.py
+++ b/tests/modules/test_autocomplete.py
@@ -126,7 +126,6 @@ def test_with_valid_query_and_filters():
     assert isinstance(response.get('sections'), dict)
     assert isinstance(response.get('result_id'), str)
     assert response.get('request').get('filters') == expected_filters
-    print(response)
 
 def test_with_valid_query_and_multiple_filters():
     '''Should return a response with a valid query and multiple filters'''

--- a/tests/modules/test_autocomplete.py
+++ b/tests/modules/test_autocomplete.py
@@ -117,11 +117,16 @@ def test_with_valid_query_and_filters():
     filters = { 'keywords': ['battery-powered'] }
     autocomplete = ConstructorIO(VALID_OPTIONS).autocomplete
     response = autocomplete.get_autocomplete_results(QUERY, { 'filters': filters })
+    expected_filters = filters.copy()
+    expected_filters['Content'] = filters
+    expected_filters['Search Suggestions'] = filters
+    expected_filters['Products'] = filters
 
     assert isinstance(response.get('request'), dict)
     assert isinstance(response.get('sections'), dict)
     assert isinstance(response.get('result_id'), str)
-    assert response.get('request').get('filters') == filters
+    assert response.get('request').get('filters') == expected_filters
+    print(response)
 
 def test_with_valid_query_and_multiple_filters():
     '''Should return a response with a valid query and multiple filters'''
@@ -129,11 +134,15 @@ def test_with_valid_query_and_multiple_filters():
     filters = { 'group_id': ['All'], 'Brand': ['XYZ'] }
     autocomplete = ConstructorIO(VALID_OPTIONS).autocomplete
     response = autocomplete.get_autocomplete_results(QUERY, { 'filters': filters })
+    expected_filters = filters.copy()
+    expected_filters['Content'] = filters
+    expected_filters['Search Suggestions'] = filters
+    expected_filters['Products'] = filters
 
     assert isinstance(response.get('request'), dict)
     assert isinstance(response.get('sections'), dict)
     assert isinstance(response.get('result_id'), str)
-    assert response.get('request').get('filters') == filters
+    assert response.get('request').get('filters') == expected_filters
     assert len(response.get('sections').get('Products')) >= 1
 
 def test_with_valid_query_and_user_ip():


### PR DESCRIPTION
Autocomplete now returns a per-section filters applied in the `request` object. This PR addresses that.

Note: Quizzes tests are failing but that's due to a backend issue w.r.t. backwards compatibility