### PR TITLE
[CI-3704] Add Dependabot alert action

### DIFF
--- a/.github/workflows/dependabot-alerts-to-slack.yml
+++ b/.github/workflows/dependabot-alerts-to-slack.yml
@@ -1,0 +1,17 @@
+name: 'Check for Dependabot alerts & send them to slack'
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # every day at 8 am
+  workflow_dispatch: # to have the option to run this ad-hoc
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      # X.X.X - Latest version available at: https://github.com/kunalnagarco/action-cve/releases
+      - uses: kunalnagarco/action-cve@v1.13.2
+        with:
+          token: ${{ secrets.DEPENDABOT_TOKEN }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          count: 10


### PR DESCRIPTION
Temporarily uses my personal access token. I'm going to switch it to a permanent one after confirming this works as expected