### PR TITLE
Ci 4645 python sdk item groups crud

### DIFF
--- a/constructor_io/modules/catalog.py
+++ b/constructor_io/modules/catalog.py
@@ -109,6 +109,22 @@ def _create_items_url(path, options, additional_query_params):
 
     return f'{options.get("service_url")}/v2/{quote(path)}?{query_string}'
 
+def _create_item_groups_url(path, options, additional_query_params):
+    '''Create item groups API url'''
+
+    api_key = options.get('api_key')
+    version = options.get('version')
+    query_params = {**additional_query_params}
+
+    if not path or not isinstance(path, str):
+        raise ConstructorException('path is a required parameter of type string')
+
+    query_params['key'] = api_key
+    query_params['c'] = version
+    query_params = clean_params(query_params)
+    query_string = urlencode(query_params, doseq=True)
+
+    return f'{options.get("service_url")}/v1/{quote(path)}?{query_string}'
 
 class Catalog:
     '''Catalog Class'''
@@ -439,6 +455,135 @@ class Catalog:
             request_url,
             auth=create_auth_header(self.__options),
             headers=create_request_headers(self.__options),
+        )
+
+        if not response.ok:
+            throw_http_exception_from_response(response)
+
+        json = response.json()
+
+        return json
+
+    def retrieve_item_groups(self, parameters=None):
+        '''
+        Retrieve all item groups.
+
+        :param str parameters.section: The section to retrieve from
+        '''
+
+        query_params = _create_query_params_for_items(parameters)
+        request_url = _create_item_groups_url('item_groups', self.__options, query_params)
+        requests = self.__options.get('requests') or r
+
+        response = requests.get(
+            request_url,
+            auth=create_auth_header(self.__options),
+            headers=create_request_headers(self.__options)
+        )
+
+        if not response.ok:
+            throw_http_exception_from_response(response)
+
+        json = response.json()
+
+        return json
+
+    def create_item_groups(self, parameters=None):
+        '''
+        Create new item groups. If the item groups already exist, they will be skipped.
+
+        :param list parameters.item_groups: A list of item groups to create
+        :param str parameters.section: The section to update
+        '''
+
+        query_params = _create_query_params_for_items(parameters)
+        request_url = _create_item_groups_url('item_groups', self.__options, query_params)
+        requests = self.__options.get('requests') or r
+
+        response = requests.post(
+            request_url,
+            auth=create_auth_header(self.__options),
+            headers=create_request_headers(self.__options),
+            json={ 'item_groups': parameters.get('item_groups') }
+        )
+
+        if not response.ok:
+            throw_http_exception_from_response(response)
+
+        json = response.json()
+
+        return json
+
+    def create_or_replace_item_groups(self, parameters=None):
+        '''
+        Create or replace item groups. If the item groups already exist,
+        they will be updated. If not, they will be created.
+        Existing item groups not sent in the request will be deleted.
+
+        :param list parameters.item_groups: A list of item groups to create or replace
+        :param str parameters.section: The section to update
+        '''
+
+        query_params = _create_query_params_for_items(parameters)
+        request_url = _create_item_groups_url('item_groups', self.__options, query_params)
+        requests = self.__options.get('requests') or r
+
+        response = requests.put(
+            request_url,
+            auth=create_auth_header(self.__options),
+            headers=create_request_headers(self.__options),
+            json={ 'item_groups': parameters.get('item_groups') }
+        )
+
+        if not response.ok:
+            throw_http_exception_from_response(response)
+
+        json = response.json()
+
+        return json
+
+    def create_or_update_item_groups(self, parameters=None):
+        '''
+        Update item groups. If the item groups already exist,
+        they will be updated. If not, they will be created.
+
+        :param list parameters.item_groups: A list of item groups to create or update
+        :param str parameters.section: The section to update
+       '''
+
+        query_params = _create_query_params_for_items(parameters)
+        request_url = _create_item_groups_url('item_groups', self.__options, query_params)
+        requests = self.__options.get('requests') or r
+
+        response = requests.patch(
+            request_url,
+            auth=create_auth_header(self.__options),
+            headers=create_request_headers(self.__options),
+            json={ 'item_groups': parameters.get('item_groups') }
+        )
+
+        if not response.ok:
+            throw_http_exception_from_response(response)
+
+        json = response.json()
+
+        return json
+
+    def delete_item_groups(self, parameters=None):
+        '''
+        Delete all item groups.
+
+        :param str parameters.section: The section to delete from
+        '''
+
+        query_params = _create_query_params_for_items(parameters)
+        request_url = _create_item_groups_url('item_groups', self.__options, query_params)
+        requests = self.__options.get('requests') or r
+
+        response = requests.delete(
+            request_url,
+            auth=create_auth_header(self.__options),
+            headers=create_request_headers(self.__options)
         )
 
         if not response.ok:

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -51,3 +51,22 @@ def create_mock_variation(item_id=None):
     }
 
     return variation
+
+def create_mock_item_group():
+    '''Creates a mock item group to be used in Item Groups API tests'''
+    item_group_id = str(uuid.uuid4())
+    name = 'Item Group ' + item_group_id
+    data = {
+        'complexMetadataField': {
+            'key1': 'val1',
+            'key2': 'val2',
+        }
+    }
+    item_group = {
+        'id': item_group_id,
+        'name': name,
+        'data': data,
+        'children': []
+    }
+
+    return item_group

--- a/tests/modules/test_catalog_item_groups.py
+++ b/tests/modules/test_catalog_item_groups.py
@@ -1,0 +1,258 @@
+'''ConstructorIO Python Client - Item Groups Catalog Tests'''
+
+from os import environ
+from time import sleep
+
+import pytest
+from pytest import raises
+
+from constructor_io.constructor_io import ConstructorIO
+from constructor_io.helpers.exception import HttpException
+from tests.helpers.utils import create_mock_item_group
+
+TEST_API_KEY = environ['TEST_CATALOG_API_KEY']
+TEST_API_TOKEN = environ['TEST_API_TOKEN']
+VALID_OPTIONS = { 'api_key': TEST_API_KEY, 'api_token': TEST_API_TOKEN }
+SECTION = 'Products'
+
+@pytest.fixture(autouse=True)
+def slow_down_tests():
+    '''Sleep between tests'''
+
+    yield
+    sleep(1)
+
+def test_create_item_groups():
+    '''Should create new item groups'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    item_groups = [
+        create_mock_item_group(),
+        create_mock_item_group()
+    ]
+    parameters = {
+        'item_groups': item_groups
+    }
+
+    response = catalog.create_item_groups(parameters)
+
+    assert response is not None
+
+    stats = response['item_groups']
+    expected_stats = {
+        'processed': 2,
+        'inserted': 2,
+        'deleted': 0,
+        'updated': 0
+    }
+
+    assert stats == expected_stats
+
+    catalog.delete_item_groups()
+
+def test_create_item_groups_validation():
+    '''Should validate item_groups parameter requirements'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    # Test with missing item_groups parameter
+    with raises(
+        HttpException,
+        match=r'item_groups: none is not an allowed value'
+    ):
+        catalog.create_item_groups({})
+
+    # Test with empty item_groups array
+    with raises(
+        HttpException,
+        match=r'item_groups: ensure this value has at least 1 items'
+    ):
+        catalog.create_item_groups({'item_groups': []})
+
+    # Test with non-array item_groups
+    with raises(
+        HttpException,
+        match=r'item_groups: value is not a valid list'
+    ):
+        catalog.create_item_groups({'item_groups': 'not an array'})
+
+def test_create_or_replace_item_groups():
+    '''Should create or replace item groups'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+    
+    initial_item_groups = [
+        create_mock_item_group(),
+        create_mock_item_group(),
+    ]
+    parameters = {
+        'item_groups': initial_item_groups
+    }
+
+    response = catalog.create_item_groups(parameters)
+
+    updated_item_groups = [
+        # Keep one existing item group but modify it
+        {**initial_item_groups[0], 'name': 'Updated Name'},
+        create_mock_item_group(),
+    ]
+    parameters = {
+        'item_groups': updated_item_groups
+    }
+
+    response = catalog.create_or_replace_item_groups(parameters)
+
+    assert response is not None
+
+    stats = response['item_groups']
+    expected_stats = {
+        'processed': 2,
+        'inserted': 1, 
+        'updated': 1,
+        'deleted': 1
+    }
+
+    assert stats == expected_stats
+
+def test_create_or_replace_item_groups_validation():
+    '''Should validate item_groups parameter requirements for create_or_replace'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    # Test with missing item_groups parameter
+    with raises(
+        HttpException,
+        match=r'item_groups: none is not an allowed value'
+    ):
+        catalog.create_or_replace_item_groups({})
+
+    # Test with empty item_groups array
+    with raises(
+        HttpException,
+        match=r'item_groups: ensure this value has at least 1 items'
+    ):
+        catalog.create_or_replace_item_groups({'item_groups': []})
+
+    # Test with non-array item_groups
+    with raises(
+        HttpException,
+        match=r'item_groups: value is not a valid list'
+    ):
+        catalog.create_or_replace_item_groups({'item_groups': 'not an array'})
+
+def test_retrieve_item_groups():
+    '''Should retrieve all item groups'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    item_groups = [
+        create_mock_item_group(),
+        create_mock_item_group()
+    ]
+    parameters = {
+        'item_groups': item_groups
+    }
+
+    response = catalog.create_item_groups(parameters)
+
+    assert response is not None
+
+    retrieve_response = catalog.retrieve_item_groups()
+
+    assert retrieve_response is not None
+    assert 'item_groups' in retrieve_response
+
+    catalog.delete_item_groups()
+
+
+def test_delete_item_groups():
+    '''Should delete all item groups'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    item_groups = [
+        create_mock_item_group(),
+        create_mock_item_group()
+    ]
+    parameters = {
+        'item_groups': item_groups
+    }
+
+    response = catalog.create_item_groups(parameters)
+
+    assert response is not None
+
+    delete_response = catalog.delete_item_groups()
+
+    assert delete_response is not None
+    assert 'message' in delete_response
+    assert delete_response['message'] == 'We\'ve started deleting all of your groups. This may take some time to complete.'
+
+
+def test_create_or_update_item_groups():
+    '''Should create or update item groups'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    initial_item_groups = [
+        create_mock_item_group(),
+        create_mock_item_group(),
+    ]
+    parameters = {
+        'item_groups': initial_item_groups
+    }
+
+    response = catalog.create_item_groups(parameters)
+
+    updated_item_groups = [
+        # Keep one existing item group but modify it
+        {**initial_item_groups[0], 'name': 'Updated Name'},
+        create_mock_item_group(),
+    ]
+    parameters = {
+        'item_groups': updated_item_groups
+    }
+
+    response = catalog.create_or_update_item_groups(parameters)
+
+    assert response is not None
+
+    stats = response['item_groups']
+    expected_stats = {
+        'processed': 2,
+        'inserted': 1,
+        'updated': 1,
+        'deleted': 0
+    }
+
+    assert stats == expected_stats
+
+    catalog.delete_item_groups()
+
+
+def test_create_or_update_item_groups_validation():
+    '''Should validate item_groups parameter requirements for create_or_update'''
+
+    catalog = ConstructorIO(VALID_OPTIONS).catalog
+
+    # Test with missing item_groups parameter
+    with raises(
+        HttpException,
+        match=r'item_groups: none is not an allowed value'
+    ):
+        catalog.create_or_update_item_groups({})
+
+    # Test with empty item_groups array
+    with raises(
+        HttpException,
+        match=r'item_groups: ensure this value has at least 1 items'
+    ):
+        catalog.create_or_update_item_groups({'item_groups': []})
+
+    # Test with non-array item_groups
+    with raises(
+        HttpException,
+        match=r'item_groups: value is not a valid list'
+    ):
+        catalog.create_or_update_item_groups({'item_groups': 'not an array'})

--- a/tests/modules/test_catalog_item_groups.py
+++ b/tests/modules/test_catalog_item_groups.py
@@ -81,7 +81,7 @@ def test_create_or_replace_item_groups():
     '''Should create or replace item groups'''
 
     catalog = ConstructorIO(VALID_OPTIONS).catalog
-    
+
     initial_item_groups = [
         create_mock_item_group(),
         create_mock_item_group(),
@@ -187,7 +187,8 @@ def test_delete_item_groups():
 
     assert delete_response is not None
     assert 'message' in delete_response
-    assert delete_response['message'] == 'We\'ve started deleting all of your groups. This may take some time to complete.'
+    expected_message = 'We\'ve started deleting all of your groups. This may take some time to complete.'
+    assert delete_response['message'] == expected_message
 
 
 def test_create_or_update_item_groups():


### PR DESCRIPTION
# Changes 🐍 

- Added support for [Item Groups](https://docs.constructor.com/reference/catalog-management-item-groups) catalog methods 🍏 
   - [Retrieve item groups](https://docs.constructor.com/reference/v1-item-groups-retrieve-item-groups)
       - `retrieve_item_groups`
   - [Create new item groups](https://docs.constructor.com/reference/v1-item-groups-create-item-groups)
       - `create_item_groups` 
   - [Create or replace item groups ](https://docs.constructor.com/reference/v1-item-groups-create-or-replace-item-groups)
       - `create_or_replace_item_groups` 
   - [Create or update item groups](https://docs.constructor.com/reference/v1-item-groups-create-or-update-item-groups)
       - `create_or_update_item_groups` 
   - [Delete item groups](https://docs.constructor.com/reference/v1-item-groups-delete-item-groups)
       -  `delete_item_groups`
- Added tests 🧪  
